### PR TITLE
Resolve #12: Ordena las entradas por fecha

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   },
   "prettier": {},
   "dependencies": {
-    "@frontity/core": "^1.5.3",
-    "@frontity/html2react": "^1.3.2",
+    "@frontity/core": "^1.7.0",
+    "@frontity/html2react": "^1.3.3",
     "@frontity/tiny-router": "^1.2.0",
-    "@frontity/wp-source": "^1.7.0",
-    "frontity": "^1.6.0",
+    "@frontity/wp-source": "^1.7.1",
+    "frontity": "^1.8.0",
     "reciclateya-theme": "file:packages/reciclateya-theme"
   }
 }

--- a/packages/reciclateya-theme/src/components/PostsList.js
+++ b/packages/reciclateya-theme/src/components/PostsList.js
@@ -122,9 +122,7 @@ const PostsList = ({ state, libraries }) => {
         {posts.map((post) => {
           return (
             <Link href={post.link} key={post.id}>
-              <h2>
-                {renderText(post.title.rendered)} {post.id}
-              </h2>
+              <h2>{renderText(post.title.rendered)}</h2>
               <date>Escrito el {formatDate(post.date)}</date>
               <Html2React html={post.excerpt.rendered} />
             </Link>

--- a/packages/reciclateya-theme/src/components/PostsList.js
+++ b/packages/reciclateya-theme/src/components/PostsList.js
@@ -10,8 +10,9 @@ const PostsList = ({ state, libraries }) => {
     libraries.source.populate({ response, state });
   });
 
-  const keys = Object.keys(state.source.post);
-  const posts = state.source.post;
+  const posts = Object.values(state.source.post).sort(
+    (a, b) => new Date(b.date) - new Date(a.date)
+  );
 
   const Html2React = libraries.html2react.Component;
 
@@ -118,12 +119,14 @@ const PostsList = ({ state, libraries }) => {
         </div>
       </PostHeader>
       <Items>
-        {keys.map((id) => {
+        {posts.map((post) => {
           return (
-            <Link href={posts[id].link} key={id}>
-              <h2>{renderText(posts[id].title.rendered)}</h2>
-              <date>Escrito el {formatDate(posts[id].date)}</date>
-              <Html2React html={posts[id].excerpt.rendered} />
+            <Link href={post.link} key={post.id}>
+              <h2>
+                {renderText(post.title.rendered)} {post.id}
+              </h2>
+              <date>Escrito el {formatDate(post.date)}</date>
+              <Html2React html={post.excerpt.rendered} />
             </Link>
           );
         })}


### PR DESCRIPTION
WP está devolviendo bien las entradas, excepto por un campo `id` que no
sé de dónde sale. Por lo tanto, lo que hago es ordenar las entradas que
tengo por el campo `date` descendente.

Actualiza las dependencias